### PR TITLE
correct init image header with hdu name

### DIFF
--- a/wisardgui.pro
+++ b/wisardgui.pro
@@ -661,7 +661,15 @@ end
 ; issue #13 : "Software shouldn't change their inputs"
 ; reinterpret input parameters and add correct values to images
 ; Just copy back 
-     mwrfits,save_init_image,output,init_image_header,/silent,/no_copy,/no_comment
+     ; remove wrong parameters
+     sxdelpar, init_img_header, ['SIMPLE','EXTEND']
+     ; remove wrongly placed parameters
+     sxdelpar, init_img_header, ['PCOUNT','GCOUNT']
+     ; put them back at the correct place
+     sxaddpar, init_img_header, 'PCOUNT',0,'required keyword; must = 0',AFTER='NAXIS2'
+     sxaddpar, init_img_header, 'GCOUNT',1,'required keyword; must = 1',AFTER='PCOUNT'
+     ; write init image with corrected init header
+     mwrfits,save_init_image,output,init_img_header,/silent,/no_copy,/no_comment
   endif
 
   mwrfits,oitarget,output,targethead,/silent,/no_copy,/no_comment


### PR DESCRIPTION
Problem was WISARD was not giving back the correct HDU NAME with the init image header.
In fact it was using a non-existent variable, which was resulting in null value, so mwrfits was generating a default header.
This PR:
- uses the correct initial image header read by mrdfits
- removes unwanted parameters SIMPLE & EXTEND
- moves at the correct place (the one that OImaging will be able to parse) the keywords PCOUNT & GCOUNT